### PR TITLE
[BUG] 7127 【OS X,firefox】2.12/Sprint-4:会议室,修改以数字“0”命名的会议室，修改菜单上会议室的名字显示为...

### DIFF
--- a/libraries/uri.php
+++ b/libraries/uri.php
@@ -75,7 +75,7 @@ abstract class _URI {
 	
 	static function anchor($url, $text = NULL, $extra=NULL, $options=array()) {
 		if ($extra) $extra = ' '.$extra;
-		if (!$text) $text = $url;
+		if ($text === NULL) $text = $url;
 		$url = URI::url($url, $options['query'], $options['fragment']);
 		return '<a href="'.$url.'"'.$extra.'>'.$text.'</a>';
 	}


### PR DESCRIPTION
...网址。

```
Task#无
```

Unit Tests:
    \* 无
Test Cases:
    \* 无

lint.php PASSED
