### PR TITLE
BUG#4930 名字中有特殊符号的的供应商不能跟订单中的供应商关联起来

### DIFF
--- a/libraries/q/query.php
+++ b/libraries/q/query.php
@@ -130,7 +130,7 @@ class Q_Query {
 		}
 	}
 
-	const PATTERN_FIELD_EXPRESSION = '/\s*(!?)((?:[\w\pL-\~])+)\s*(?:(\^=|\$=|\*=|!=|<=|>=|<|>|=)\s*(.*?)|)\s*(?:\||&|$)/u';
+	const PATTERN_FIELD_EXPRESSION = '/\s*(!?)((?:[\w\pL-\~])+)\s*(?:(\^=|\$=|\*=|!=|<=|>=|<|>|=)\s*(.*?)|)\s*(?:\||$)/u';
 	const PATTERN_FIELD_VALUE = '/(?:(-?[\w_\d.]*)~(-?[\w_\d.]*)|"((?:[^"]|\\")*)"|([^\s,]+))\s*(?:,\s*|$)|(^$)/u';
 	const PATTERN_FIELD_OBJECT = '/(\w+)#(-?\d+)/';
 


### PR DESCRIPTION

仅仅去掉了&符号的功能