### PR TITLE
Q语句解析sort(tablename.field) 再次修改

### DIFF
--- a/libraries/q/pseudo/sort.php
+++ b/libraries/q/pseudo/sort.php
@@ -4,7 +4,7 @@ class Q_Pseudo_Sort implements Q_Pseudo {
 
 	static $guid = 0;
 	
-	const SORT_PATTERN = '/([\w\pL._-]+)\s*(DESC|ASC|↓|D|A|↑)?(\s*,\s*)?/';
+	const SORT_PATTERN = '/([\w\pL\._-]+)\s*(DESC|ASC|↓|D|A|↑)?(\s*,\s*)?/';
 
 	private $_query;
 
@@ -23,7 +23,7 @@ class Q_Pseudo_Sort implements Q_Pseudo {
 				$table = count($field_arr) ? $query->alias[array_pop($field_arr)] : $query->table;
 				$order = $part[2];
 				$order=preg_match('/^↓|D|DESC$/', $order) ? 'DESC':'ASC';
-				$query->order_by[] = $db->make_ident($table, $field).' '.$order;
+				$query->order_by += [$db->make_ident($table, $field).' '.$order];
 			}
 		}
 	}

--- a/libraries/q/pseudo/sort.php
+++ b/libraries/q/pseudo/sort.php
@@ -4,7 +4,7 @@ class Q_Pseudo_Sort implements Q_Pseudo {
 
 	static $guid = 0;
 	
-	const SORT_PATTERN = '/([\w\pL_-]+)\s*(DESC|ASC|↓|D|A|↑)?(\s*,\s*)?/';
+	const SORT_PATTERN = '/([\w\pL._-]+)\s*(DESC|ASC|↓|D|A|↑)?(\s*,\s*)?/';
 
 	private $_query;
 
@@ -17,10 +17,13 @@ class Q_Pseudo_Sort implements Q_Pseudo {
 		if (preg_match_all(self::SORT_PATTERN, $selector, $parts, PREG_SET_ORDER)) {
 			$db = $query->db;
 			foreach($parts as $part){
-				$field = $part[1];
+				$field_str = $part[1];
+				$field_arr = explode('.', $field_str);
+				$field = array_pop($field_arr);
+				$table = count($field_arr) ? $query->alias[array_pop($field_arr)] : $query->table;
 				$order = $part[2];
 				$order=preg_match('/^↓|D|DESC$/', $order) ? 'DESC':'ASC';
-				$query->order_by[] = $db->make_ident($query->table, $field).' '.$order;
+				$query->order_by[] = $db->make_ident($table, $field).' '.$order;
 			}
 		}
 	}

--- a/libraries/q/query.php
+++ b/libraries/q/query.php
@@ -26,7 +26,7 @@ class Q_Query {
 	public $join;
 	public $where;
 	public $limit;
-	public $order_by;
+	public $order_by = array();
 
 	public $join_criteria = array();
 	public $join_tables = array();
@@ -39,7 +39,7 @@ class Q_Query {
 	private $prev_or_query;
 	private $prev_and_query;
 
-	private static $storable = array('prev_name', 'prev_table', 'where', 'rels', 'join_tables', 'join_criteria', 'alias', 'table_name');
+	private static $storable = array('prev_name', 'prev_table', 'where', 'rels', 'join_tables', 'join_criteria', 'table_name');
 
 	function fields($name) {
 		return ORM_Model::fields($name);


### PR DESCRIPTION
上次修改后发现一些问题，
1、修复了 解析sql语句 tablename为空''bug；
2、修复了 order by 出现多次重复条件bug。

