### PR TITLE
去掉默认的id排序

### DIFF
--- a/libraries/q/query.php
+++ b/libraries/q/query.php
@@ -672,9 +672,6 @@ class Q_Query {
             if ($this->order_by) {
                 $SQL .= ' ORDER BY '.implode(', ', $this->order_by);
             }
-            else {
-                $SQL .= ' ORDER BY '.$db->make_ident($this->table, 'id');
-            }
 
 			if ($this->limit) {
 				$SQL .= ' LIMIT '.$this->limit;


### PR DESCRIPTION
所有的q语句都会默认增加id排序
会极大的影响语句性能
需要去掉 使用者再依据情况判定是否需要排序